### PR TITLE
Adds curse reset system with cooldown and admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A dynamic survival challenge plugin for Minecraft that introduces plague-style s
 - **Combat Radius**: Stay within the designated area or face consequences
 - **Poison Penalty**: Failure results in deadly poisoning until antidote is consumed
 - **Final Wave**: Unwinnable challenge that forces strategic antidote usage
+- **Automatic Reset**: Curse resets on player death or quit/rejoin
+- **Cooldown System**: Configurable cooldown period after curse reset
+- **Admin Commands**: Full admin control over player curses
 
 ## Installation
 
@@ -49,10 +52,29 @@ The compiled JAR will be available in the `target/` directory.
 3. Survive the waves of enhanced zombies
 4. Use the antidote from the first reward chest to end the curse
 
+### Curse Reset Conditions
+
+**The curse will automatically reset in the following situations:**
+
+- **Player Death**: All progress is lost and a cooldown is applied
+- **Player Quit/Rejoin**: Progress is lost and a cooldown is applied
+- **Admin Reset**: Administrators can manually reset any player's curse
+
+**After a reset, you must wait for the cooldown period (default: 5 minutes) before starting a new curse.**
+
+### Admin Commands
+
+Administrators can manage player curses using the following commands:
+
+- `/curse start <player>` - Force start a curse on a specific player
+- `/curse stop <player>` - Force stop a specific player's curse
+- `/curse reset <player>` - Reset a player's curse and apply cooldown
+
 ### Commands
 
-- `/curse start` - Force start a curse (admin only)
-- `/curse stop` - Force stop current curse (admin only)
+- `/curse start [player]` - Force start a curse (admin only)
+- `/curse stop [player]` - Force stop current curse (admin only)
+- `/curse reset [player]` - Reset a curse and apply cooldown (admin only)
 - `/curse leaderboard` - View curse statistics and rankings
 - `/curse reload` - Reload plugin configuration (admin only)
 - `/curse help` - Show available commands
@@ -63,6 +85,7 @@ The compiled JAR will be available in the `target/` directory.
 - `curse.use` - Basic usage and leaderboard access (default: true)
 - `curse.start` - Can force start curses (default: op)
 - `curse.stop` - Can force stop curses (default: op)
+- `curse.reset` - Can reset curses and apply cooldown (default: op)
 - `curse.reload` - Can reload configuration (default: op)
 
 ## Configuration
@@ -80,6 +103,7 @@ plague:
   visualEffects: true            # Enable particle and sound effects
   combatRadius: 30               # Maximum distance from start location
   minDistanceFromVillages: 100   # Minimum distance from villages
+  resetCooldownMinutes: 5        # Cooldown after curse reset (minutes)
 
 rewards:
   chestLoot:                     # Configurable loot tables
@@ -164,9 +188,14 @@ If you encounter any issues or have questions:
 
 ## Changelog
 
-### Version 1.0.0
+### Version 0.1.0
+
 - Initial release
 - Core plague system implementation
 - Boss bar and leaderboard integration
 - Configurable reward system
 - Persistent data storage
+- **NEW**: Automatic curse reset on player death
+- **NEW**: Curse reset on quit/rejoin with cooldown system
+- **NEW**: Admin commands for managing player curses
+- **NEW**: Configurable cooldown period (default: 5 minutes)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 19132:19132/udp
     volumes:
       - minecraft:/minecraft
-      - ./target/curse-0.1.0.jar:/minecraft/plugins/curse-0.1.0.jar
+      - ./target/curse-0.1.1.jar:/minecraft/plugins/curse-0.1.1.jar
     stdin_open: true # docker run -i
     tty: true # docker run -t
     entrypoint: ["/bin/bash", "/scripts/start.sh"]

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -29,7 +29,7 @@ print_error() {
 }
 
 # Ensure plugin is built
-if [[ ! -f "target/curse-0.1.0.jar" ]]; then
+if [[ ! -f "target/curse-0.1.1.jar" ]]; then
     print_error "Plugin JAR not found. Run 'make build' first."
     exit 1
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.xpfarm</groupId>
     <artifactId>curse</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>The Curse</name>

--- a/server-manager.sh
+++ b/server-manager.sh
@@ -8,7 +8,7 @@ set -e
 # Configuration
 SERVER_DIR="server"
 PLUGIN_NAME="curse"
-PLUGIN_JAR="target/${PLUGIN_NAME}-0.1.0.jar"
+PLUGIN_JAR="target/${PLUGIN_NAME}-0.1.1.jar"
 SERVER_JAR="paper.jar"
 MIN_RAM="2G"
 MAX_RAM="4G"
@@ -231,7 +231,7 @@ show_status() {
     fi
     
     # Check plugin status
-    if [[ -f "$SERVER_DIR/plugins/${PLUGIN_NAME}-0.1.0.jar" ]]; then
+    if [[ -f "$SERVER_DIR/plugins/${PLUGIN_NAME}-0.1.1.jar" ]]; then
         print_success "The Curse plugin is installed"
     else
         print_warning "The Curse plugin is not installed"

--- a/src/main/java/org/xpfarm/curse/CursePlugin.java
+++ b/src/main/java/org/xpfarm/curse/CursePlugin.java
@@ -7,6 +7,7 @@ import org.xpfarm.curse.listeners.PotionListener;
 import org.xpfarm.curse.managers.PlagueManager;
 import org.xpfarm.curse.managers.LeaderboardManager;
 import org.xpfarm.curse.managers.ConfigManager;
+import org.xpfarm.curse.managers.CooldownManager;
 import org.xpfarm.curse.utils.MessageUtil;
 
 import net.kyori.adventure.text.Component;
@@ -18,6 +19,7 @@ public class CursePlugin extends JavaPlugin {
     private PlagueManager plagueManager;
     private LeaderboardManager leaderboardManager;
     private ConfigManager configManager;
+    private CooldownManager cooldownManager;
     
     @Override
     public void onEnable() {
@@ -25,6 +27,7 @@ public class CursePlugin extends JavaPlugin {
         
         // Initialize managers
         configManager = new ConfigManager(this);
+        cooldownManager = new CooldownManager(this);
         plagueManager = new PlagueManager(this);
         leaderboardManager = new LeaderboardManager(this);
         
@@ -86,6 +89,10 @@ public class CursePlugin extends JavaPlugin {
     
     public ConfigManager getConfigManager() {
         return configManager;
+    }
+    
+    public CooldownManager getCooldownManager() {
+        return cooldownManager;
     }
     
     public void reloadPlugin() {

--- a/src/main/java/org/xpfarm/curse/CursePlugin.java
+++ b/src/main/java/org/xpfarm/curse/CursePlugin.java
@@ -8,7 +8,6 @@ import org.xpfarm.curse.managers.PlagueManager;
 import org.xpfarm.curse.managers.LeaderboardManager;
 import org.xpfarm.curse.managers.ConfigManager;
 import org.xpfarm.curse.managers.CooldownManager;
-import org.xpfarm.curse.utils.MessageUtil;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;

--- a/src/main/java/org/xpfarm/curse/listeners/PlayerListener.java
+++ b/src/main/java/org/xpfarm/curse/listeners/PlayerListener.java
@@ -3,6 +3,7 @@ package org.xpfarm.curse.listeners;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -91,17 +92,20 @@ public class PlayerListener implements Listener {
         }
     }
     
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
         
+        // Early return if no active plague to improve performance
+        if (!plugin.getPlagueManager().hasActivePlague(player)) {
+            return;
+        }
+        
         // Check if player has active plague and moved significantly
-        if (plugin.getPlagueManager().hasActivePlague(player)) {
-            Plague plague = plugin.getPlagueManager().getPlague(player);
-            if (plague != null && plague.isActive()) {
-                // Distance check is handled in PlagueManager monitoring task
-                // This event can be used for other movement-based features if needed
-            }
+        Plague plague = plugin.getPlagueManager().getPlague(player);
+        if (plague != null && plague.isActive()) {
+            // Distance check is handled in PlagueManager monitoring task
+            // This event can be used for other movement-based features if needed
         }
     }
 }

--- a/src/main/java/org/xpfarm/curse/managers/ConfigManager.java
+++ b/src/main/java/org/xpfarm/curse/managers/ConfigManager.java
@@ -36,7 +36,7 @@ public class ConfigManager {
     }
     
     public int getTimeLimitPerRound() {
-        return config.getInt("plague.timeLimitPerRound", 60);
+        return config.getInt("plague.timeLimitPerRound", 180);
     }
     
     public boolean isAllowTerrainDamage() {

--- a/src/main/java/org/xpfarm/curse/managers/ConfigManager.java
+++ b/src/main/java/org/xpfarm/curse/managers/ConfigManager.java
@@ -59,6 +59,10 @@ public class ConfigManager {
         return config.getInt("plague.minDistanceFromVillages", 100);
     }
     
+    public int getResetCooldownMinutes() {
+        return config.getInt("plague.resetCooldownMinutes", 5);
+    }
+    
     // Leaderboard Configuration
     public boolean isLeaderboardEnabled() {
         return config.getBoolean("leaderboard.enabled", true);

--- a/src/main/java/org/xpfarm/curse/managers/ConfigManager.java
+++ b/src/main/java/org/xpfarm/curse/managers/ConfigManager.java
@@ -55,6 +55,14 @@ public class ConfigManager {
         return config.getInt("plague.combatRadius", 30);
     }
     
+    public int getWarningDistance() {
+        return config.getInt("plague.warningDistance", 5);
+    }
+    
+    public int getWarningCooldownSeconds() {
+        return config.getInt("plague.warningCooldownSeconds", 10);
+    }
+    
     public int getMinDistanceFromVillages() {
         return config.getInt("plague.minDistanceFromVillages", 100);
     }

--- a/src/main/java/org/xpfarm/curse/managers/CooldownManager.java
+++ b/src/main/java/org/xpfarm/curse/managers/CooldownManager.java
@@ -1,0 +1,72 @@
+package org.xpfarm.curse.managers;
+
+import org.bukkit.entity.Player;
+import org.xpfarm.curse.CursePlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class CooldownManager {
+    
+    private final CursePlugin plugin;
+    private final Map<UUID, Long> cooldowns;
+    
+    public CooldownManager(CursePlugin plugin) {
+        this.plugin = plugin;
+        this.cooldowns = new HashMap<>();
+    }
+    
+    public void setCooldown(Player player) {
+        setCooldown(player.getUniqueId());
+    }
+    
+    public void setCooldown(UUID playerId) {
+        long cooldownTime = System.currentTimeMillis() + (plugin.getConfigManager().getResetCooldownMinutes() * 60 * 1000L);
+        cooldowns.put(playerId, cooldownTime);
+    }
+    
+    public boolean hasCooldown(Player player) {
+        return hasCooldown(player.getUniqueId());
+    }
+    
+    public boolean hasCooldown(UUID playerId) {
+        Long cooldownTime = cooldowns.get(playerId);
+        if (cooldownTime == null) {
+            return false;
+        }
+        
+        if (System.currentTimeMillis() >= cooldownTime) {
+            cooldowns.remove(playerId);
+            return false;
+        }
+        
+        return true;
+    }
+    
+    public long getRemainingCooldownSeconds(Player player) {
+        return getRemainingCooldownSeconds(player.getUniqueId());
+    }
+    
+    public long getRemainingCooldownSeconds(UUID playerId) {
+        Long cooldownTime = cooldowns.get(playerId);
+        if (cooldownTime == null) {
+            return 0;
+        }
+        
+        long remaining = cooldownTime - System.currentTimeMillis();
+        return Math.max(0, remaining / 1000);
+    }
+    
+    public void removeCooldown(Player player) {
+        removeCooldown(player.getUniqueId());
+    }
+    
+    public void removeCooldown(UUID playerId) {
+        cooldowns.remove(playerId);
+    }
+    
+    public void clearAllCooldowns() {
+        cooldowns.clear();
+    }
+}

--- a/src/main/java/org/xpfarm/curse/managers/PlagueManager.java
+++ b/src/main/java/org/xpfarm/curse/managers/PlagueManager.java
@@ -2,8 +2,9 @@ package org.xpfarm.curse.managers;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.boss.BarColor;
@@ -171,8 +172,11 @@ public class PlagueManager {
         
         // Scale zombie based on round
         double healthMultiplier = 1.0 + (round * 0.5);
-        zombie.setMaxHealth(zombie.getMaxHealth() * healthMultiplier);
-        zombie.setHealth(zombie.getMaxHealth());
+        AttributeInstance maxHealthAttr = zombie.getAttribute(Attribute.MAX_HEALTH);
+        if (maxHealthAttr != null) {
+            maxHealthAttr.setBaseValue(maxHealthAttr.getBaseValue() * healthMultiplier);
+            zombie.setHealth(maxHealthAttr.getValue());
+        }
         
         // Add speed based on round
         if (round > 2) {
@@ -184,7 +188,7 @@ public class PlagueManager {
             giveZombieArmor(zombie, round);
         }
         
-        // Prevent despawning
+        // Prevent entity from disappearing naturally
         zombie.setPersistent(true);
         
         // Custom name
@@ -258,15 +262,14 @@ public class PlagueManager {
         ItemStack potion = new ItemStack(Material.POTION);
         PotionMeta meta = (PotionMeta) potion.getItemMeta();
         
-        meta.setDisplayName("§aCurse Antidote"); // Use legacy color codes
-        List<String> lore = Arrays.asList(
-            "§7Ends the current curse",
-            "§eUse wisely!"
+        meta.displayName(Component.text("Curse Antidote", NamedTextColor.GREEN));
+        List<Component> lore = Arrays.asList(
+            Component.text("Ends the current curse", NamedTextColor.GRAY),
+            Component.text("Use wisely!", NamedTextColor.YELLOW)
         );
-        meta.setLore(lore);
+        meta.lore(lore);
         
-        // Create custom potion using NamespacedKey
-        NamespacedKey key = new NamespacedKey(plugin, "curse_antidote");
+        // Create custom potion for healing appearance
         meta.setBasePotionType(PotionType.HEALING); // Base type for appearance
         
         potion.setItemMeta(meta);
@@ -277,12 +280,12 @@ public class PlagueManager {
         ItemStack potion = new ItemStack(Material.POTION);
         PotionMeta meta = (PotionMeta) potion.getItemMeta();
         
-        meta.setDisplayName("§9Undo Potion"); // Use legacy color codes
-        List<String> lore = Arrays.asList(
-            "§7Reverses damage from last round",
-            "§6Very rare!"
+        meta.displayName(Component.text("Undo Potion", NamedTextColor.BLUE));
+        List<Component> lore = Arrays.asList(
+            Component.text("Reverses damage from last round", NamedTextColor.GRAY),
+            Component.text("Very rare!", NamedTextColor.GOLD)
         );
-        meta.setLore(lore);
+        meta.lore(lore);
         
         meta.setBasePotionType(PotionType.HEALING);
         
@@ -294,12 +297,12 @@ public class PlagueManager {
         ItemStack potion = new ItemStack(Material.POTION);
         PotionMeta meta = (PotionMeta) potion.getItemMeta();
         
-        meta.setDisplayName("§4Curse Trigger"); // Use legacy color codes for compatibility
-        List<String> lore = Arrays.asList(
-            "§7Drink at night to start The Curse",
-            "§cBeware the undead plague!"
+        meta.displayName(Component.text("Curse Trigger", NamedTextColor.DARK_RED));
+        List<Component> lore = Arrays.asList(
+            Component.text("Drink at night to start The Curse", NamedTextColor.GRAY),
+            Component.text("Beware the undead plague!", NamedTextColor.RED)
         );
-        meta.setLore(lore);
+        meta.lore(lore);
         
         meta.setBasePotionType(PotionType.AWKWARD); // Base type for appearance
         meta.addCustomEffect(new PotionEffect(PotionEffectType.BAD_OMEN, 1, 0), true);

--- a/src/main/java/org/xpfarm/curse/managers/PlagueManager.java
+++ b/src/main/java/org/xpfarm/curse/managers/PlagueManager.java
@@ -37,8 +37,20 @@ public class PlagueManager {
     }
     
     public boolean startPlague(Player player) {
+        return startPlague(player, false);
+    }
+    
+    public boolean startPlague(Player player, boolean bypassCooldown) {
         // Check if player already has active plague
         if (hasActivePlague(player)) {
+            return false;
+        }
+        
+        // Check cooldown unless bypassed (admin command)
+        if (!bypassCooldown && plugin.getCooldownManager().hasCooldown(player)) {
+            long remainingSeconds = plugin.getCooldownManager().getRemainingCooldownSeconds(player);
+            long remainingMinutes = remainingSeconds / 60;
+            MessageUtil.sendMessage(player, Component.text("You must wait " + remainingMinutes + " minutes before starting another curse!", NamedTextColor.RED));
             return false;
         }
         
@@ -410,5 +422,24 @@ public class PlagueManager {
                 }
             }
         }.runTaskTimer(plugin, 20L, 20L); // Check every second
+    }
+    
+    public void resetPlague(Player player) {
+        resetPlague(player, true);
+    }
+    
+    public void resetPlague(Player player, boolean setCooldown) {
+        Plague plague = activePlagues.get(player.getUniqueId());
+        if (plague != null) {
+            plague.endPlague(false);
+        }
+        
+        // Set cooldown if requested
+        if (setCooldown) {
+            plugin.getCooldownManager().setCooldown(player);
+        }
+        
+        // Send reset message
+        MessageUtil.sendMessage(player, Component.text("Your curse has been reset! You must wait before starting another one.", NamedTextColor.YELLOW));
     }
 }

--- a/src/main/java/org/xpfarm/curse/models/Plague.java
+++ b/src/main/java/org/xpfarm/curse/models/Plague.java
@@ -26,6 +26,9 @@ public class Plague {
     private boolean isActive;
     private boolean hasAntidote;
     private int initialMobCount; // Track initial mobs for health bar progress
+    private boolean isOutsideArea; // Track if player is outside cursed area
+    private boolean hasBeenWarned; // Track if player has been warned about leaving
+    private long lastWarningTime; // Track last warning time to prevent spam
     
     private BossBar bossBar;
     private List<Entity> activeMobs;
@@ -275,5 +278,29 @@ public class Plague {
     
     public void setInitialMobCount(int count) {
         this.initialMobCount = count;
+    }
+    
+    public boolean isOutsideArea() {
+        return isOutsideArea;
+    }
+    
+    public void setOutsideArea(boolean outsideArea) {
+        this.isOutsideArea = outsideArea;
+    }
+    
+    public boolean hasBeenWarned() {
+        return hasBeenWarned;
+    }
+    
+    public void setHasBeenWarned(boolean hasBeenWarned) {
+        this.hasBeenWarned = hasBeenWarned;
+    }
+    
+    public long getLastWarningTime() {
+        return lastWarningTime;
+    }
+    
+    public void setLastWarningTime(long lastWarningTime) {
+        this.lastWarningTime = lastWarningTime;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,7 +13,7 @@ plague:
   spawnRadius: 20
   
   # Time limit per round (seconds, 0 = no limit)
-  timeLimitPerRound: 60
+  timeLimitPerRound: 180
   
   # Allow mobs to damage terrain
   allowTerrainDamage: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,6 +29,9 @@ plague:
   
   # Minimum distance from villages/protected areas
   minDistanceFromVillages: 100
+  
+  # Cooldown after curse reset (minutes)
+  resetCooldownMinutes: 5
 
 # Rewards Configuration
 rewards:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,8 +24,14 @@ plague:
   # Enable visual effects (particles, sounds)
   visualEffects: true
   
-  # Combat radius - leaving this area fails the plague
+  # Combat radius - leaving this area applies poison but continues curse
   combatRadius: 30
+  
+  # Warning distance - warn player when they get this close to the boundary
+  warningDistance: 5
+  
+  # Warning cooldown - seconds between warnings to prevent spam
+  warningCooldownSeconds: 10
   
   # Minimum distance from villages/protected areas
   minDistanceFromVillages: 100

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,8 +15,14 @@ commands:
 
 permissions:
   curse.admin:
-    description: Full access to curse commands
+    description: Full access to curse commands (includes all permissions)
     default: op
+    children:
+      curse.use: true
+      curse.start: true
+      curse.stop: true
+      curse.reset: true
+      curse.reload: true
   curse.use:
     description: Can use basic curse commands and drink bad omen potion
     default: true
@@ -25,6 +31,9 @@ permissions:
     default: op
   curse.stop:
     description: Can force stop a curse
+    default: op
+  curse.reset:
+    description: Can reset a curse and set cooldown
     default: op
   curse.reload:
     description: Can reload plugin configuration


### PR DESCRIPTION
Implements automatic curse reset functionality to improve gameplay balance and administrative control:

## Reset Triggers
- **Death**: Curse automatically resets when player dies
- **Quit/Rejoin**: Curse resets when player leaves and rejoins server
- **Admin Control**: New reset command for manual intervention

## Cooldown System
- Configurable cooldown period (default: 5 minutes) after curse reset
- Prevents immediate curse restart after reset events
- Enhances gameplay balance by adding consequence to failures

## Enhanced Area Management
- Replaces instant curse failure with poison effect when leaving combat area
- Adds warning system when approaching boundary
- Allows players to return to area and continue curse
- Configurable warning distance and cooldown to prevent spam

## Admin Commands
- Extends existing commands to target other players
- Adds dedicated reset command with cooldown application
- Improves administrative control over curse management

## Quality of Life
- Extends default round time to 3 minutes for better gameplay
- Enhances potion feedback with detailed cure messages
- Updates documentation with new features and mechanics